### PR TITLE
task_edit_apiの修正

### DIFF
--- a/fuel/app/classes/controller/api/task.php
+++ b/fuel/app/classes/controller/api/task.php
@@ -116,7 +116,7 @@ class Controller_Api_Task extends Controller_Rest
     }
   }
 
-  public function post_tasks($task_id = null)
+  public function patch_tasks($task_id = null)
   {
     if (!$task_id) {
       return $this->error("IDが指定されていません");
@@ -138,12 +138,28 @@ class Controller_Api_Task extends Controller_Rest
     $title = $task["title"];
 
     try {
+      $current_task_array = DB::select("*")->from("tasks")->where("id","=",$task_id)->execute()->as_array();
+      $current_task = $current_task_array[0];
+      $current_task_title = $current_task["title"];
+
+      if ($title === $current_task_title) {
+        return $this->error("タスク名を変更して下さい");
+      }
+    } catch(Exception $e) {
+      Log::debug("Error:".print_r($e->getMessage(),true));
+    }
+
+    try {
+      Log::debug("task_id:{$task_id}");
       $result = DB::update("tasks")->set(["title"=>$title,])->where("id", "=", $task_id)->execute();
       
       if ($result === 0) {
         return $this->notFoundError("該当するタスクが存在しません");
       }
-      return $this->success(null, "タスクの編集成功", 200, false);
+
+      $edited_task  = DB::select("*")->from("tasks")->where("id","=",$task_id)->execute()->as_array();
+      return $this->success($edited_task, "タスクを更新しました", 200, true);
+
     } catch (Exception $e) {
       Log::debug("Error:" . print_r($e->getMessage(), true));
       return $this->serverError("タスクの編集失敗");


### PR DESCRIPTION
やったこと
・post→pathcメソッドへ変換
・リクエストされたタスクのタイトルがリクエスト前のタスクのタイトルと同一でないかのバリデーションの追加
・レスポンスの形式の変更